### PR TITLE
change api-default protocol to grpc

### DIFF
--- a/metrics_tracing/central_config/api-defaults.hcl
+++ b/metrics_tracing/central_config/api-defaults.hcl
@@ -1,7 +1,7 @@
 Kind = "service-defaults"
 Name = "api"
 
-Protocol = "http"
+Protocol = "grpc"
 
 MeshGateway = {
   mode = "local"


### PR DESCRIPTION
Hello,
The `metrics_tracing` example doesn't work out of the box.
I don't know if it's a feature or a bug but in any case : here's a fix to get it working.